### PR TITLE
add `disconnect()` method

### DIFF
--- a/src/main/java/com/wedevol/xmpp/server/CcsClient.java
+++ b/src/main/java/com/wedevol/xmpp/server/CcsClient.java
@@ -151,6 +151,12 @@ public class CcsClient implements PacketListener {
 	public void reconnect() {
 		// Try to connect again using exponential back-off!
 	}
+	
+	public void disconnect() {
+		if (connection != null) {
+			connection.disconnect();
+		}
+	}
 
 	/**
 	 * Handles incoming messages


### PR DESCRIPTION
I find that the XMPP connection opened in `CcsClient.connect()` never closed, which may cause resource leaks. To this end, I add a `CcsClient.disconnect()` method to make developers can close the connection. Are there potential resource leaks? Please confirm this, Thanks!